### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# Set default owners
+*  @mayrmt @searhein


### PR DESCRIPTION
Since this repository is now public, such that EuroTUG participants can clone it, I have protected the `master` branch. Contributions are only possible via pull requests from now on. To control pull request approvals, this `CODEOWNERS` file manages the approval rights.