### PR TITLE
Add MueLu examples for a robust linear solver tutorial

### DIFF
--- a/configure-files/do-configure-trilinos.sh
+++ b/configure-files/do-configure-trilinos.sh
@@ -37,6 +37,10 @@ cmake \
     -D Trilinos_ENABLE_Xpetra:BOOL=ON \
       -D Xpetra_ENABLE_Experimental:BOOL=ON \
       -D Xpetra_ENABLE_Kokkos_Refactor:BOOL=ON \
+    -D Trilinos_ENABLE_Thyra=ON \
+    -D Trilinos_ENABLE_Stratimikos=ON \
+    -D Trilinos_ENABLE_MueLu=ON \
+      -D MueLu_ENABLE_EXAMPLES=ON \
     -D Tpetra_ENABLE_TESTS:BOOL=ON \
     \
     -D TPL_ENABLE_MPI:BOOL=ON \


### PR DESCRIPTION
I'd like to add the `MueLu_Stratimikos` driver to the Trilinos configure. This is a robust driver that unites multiple packages (Ifpack2, Belos, MueLu, ...) into a single driver, and I would like to use it in my lesson if possible.