### PR TITLE
Update do-configure-trilinos

### DIFF
--- a/solutions/ex_01_configure/do-configure-trilinos
+++ b/solutions/ex_01_configure/do-configure-trilinos
@@ -27,6 +27,7 @@ cmake \
   -D Trilinos_ENABLE_Kokkos:BOOL=ON \
     -D Kokkos_ENABLE_SERIAL:BOOL=ON \
   -D Trilinos_ENABLE_Tpetra:BOOL=ON \
+  -D Trilinos_ENABLE_Amesos2:BOOL=ON \
   \
   -D TPL_ENABLE_MPI:BOOL=ON \
   -D TPL_ENABLE_BLAS:BOOL=ON \

--- a/solutions/ex_01_configure/do-configure-trilinos
+++ b/solutions/ex_01_configure/do-configure-trilinos
@@ -28,6 +28,7 @@ cmake \
     -D Kokkos_ENABLE_SERIAL:BOOL=ON \
   -D Trilinos_ENABLE_Tpetra:BOOL=ON \
   -D Trilinos_ENABLE_Amesos2:BOOL=ON \
+  -D Trilinos_ENABLE_Zoltan2:BOOL=ON \  
   \
   -D TPL_ENABLE_MPI:BOOL=ON \
   -D TPL_ENABLE_BLAS:BOOL=ON \


### PR DESCRIPTION
In the second excercise "ex_02_assemble" there is  #include <Amesos2.hpp> which is not installed. I solved the problem by adding the Amesos2 package in the configure file. 