### PR TITLE
Install Kokkos standalone

### DIFF
--- a/configure-files/do-configure-trilinos.sh
+++ b/configure-files/do-configure-trilinos.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-TYPE=RELEASE
+BUILD_TYPE=RELEASE
 
 BASE_DIR=/opt/trilinos/source
 INSTALL_DIR=/opt/trilinos/install

--- a/dockerfiles/trilinos_demo
+++ b/dockerfiles/trilinos_demo
@@ -34,22 +34,17 @@ ARG TRILINOS_CONFIGFILE=do-configure-trilinos.sh
 ARG TRILINOS_VERSION=13-4-0
 ARG GALERI_MISSING_FILE=Galeri_Exception.h
 
-WORKDIR /opt/trilinos/
-RUN wget -nv https://github.com/trilinos/Trilinos/archive/refs/tags/trilinos-release-$TRILINOS_VERSION.tar.gz
-
-# extract trilinos source file
-RUN mkdir /opt/trilinos/build
-RUN mkdir /opt/trilinos/install
-RUN tar xfz /opt/trilinos/trilinos-release-$TRILINOS_VERSION.tar.gz
-RUN mv /opt/trilinos/Trilinos-trilinos-release-$TRILINOS_VERSION /opt/trilinos/source
-RUN rm -f /opt/trilinos/trilinos-release-$TRILINOS_VERSION.tar.gz
-
-# copy configure script to build directory
-COPY $TRILINOS_CONFIGFILE /opt/trilinos/build/do-configure-trilinos.sh
-
-WORKDIR /opt/trilinos/build
-RUN ./do-configure-trilinos.sh
-RUN make -j4 && make install
+WORKDIR /opt/trilinos
+COPY $TRILINOS_CONFIGFILE /opt/trilinos/do-configure-trilinos.sh
+RUN wget -nv https://github.com/trilinos/Trilinos/archive/refs/tags/trilinos-release-$TRILINOS_VERSION.tar.gz && \
+    mkdir source && \
+    tar xfz /opt/trilinos/trilinos-release-$TRILINOS_VERSION.tar.gz -C /opt/trilinos/source --strip-components=1 && \
+    rm -f /opt/trilinos/trilinos-release-$TRILINOS_VERSION.tar.gz && \
+    mkdir build && pushd build && \
+    ../do-configure-trilinos.sh && popd && \
+    rm do-configure-trilinos.sh && \
+    cmake --build build --parallel 4 && cmake --install build --prefix . && \
+    rm -rf build source
 
 # copy missing header to include/ in install directory
 COPY $GALERI_MISSING_FILE /usr/local/include/

--- a/dockerfiles/trilinos_demo
+++ b/dockerfiles/trilinos_demo
@@ -46,6 +46,10 @@ RUN wget -nv https://github.com/trilinos/Trilinos/archive/refs/tags/trilinos-rel
     cmake --build build --parallel 4 && cmake --install build --prefix . && \
     rm -rf build source
 
+# kokkos
+RUN git clone --depth 1 --branch 4.0.01 https://github.com/kokkos/kokkos.git && cmake -S kokkos -B kokkos/build -DKokkos_ENABLE_OPENMP=ON && cmake --build kokkos/build/ --parallel 4 && cmake --install kokkos/build/ --prefix /opt/kokkos && rm -rf kokkos/
+RUN git clone --depth 1 https://github.com/kokkos/kokkos-tutorials.git /opt/kokkos-tutorials
+
 # copy missing header to include/ in install directory
 COPY $GALERI_MISSING_FILE /usr/local/include/
 


### PR DESCRIPTION
Before this PR, the docker image is 11.1GB.  With the changes I suggest, it is 2.4GB

I got rid of the Trilinos build and source directories which I don't expect we needed to keep around.

Trilinos was installed in /usr/local and is now installed in /opt/trilinos.  It will still be found by `find_package(Trilinos)` without adding search prefixes.  The motivation for this is make sure the Kokkos headers installed as part of Trilinos do not get included accidentally.

Finally I installed Kokkos in /opt/kokkos and the tutorial material in /opt/kokkos-tutorials