### PR TITLE
Do not bother building cmake

### DIFF
--- a/dockerfiles/trilinos_demo
+++ b/dockerfiles/trilinos_demo
@@ -17,13 +17,14 @@ ENV PATH=/usr/lib64/mpich/bin/:$PATH
 FROM base AS cmake
 
 # Cmake
-WORKDIR /opt/cmake/
-RUN wget https://github.com/Kitware/CMake/releases/download/v3.27.0-rc3/cmake-3.27.0-rc3.tar.gz
-RUN tar xfz /opt/cmake/cmake-3.27.0-rc3.tar.gz
-RUN mv /opt/cmake/cmake-3.27.0-rc3/ /opt/cmake/source
-RUN rm cmake-3.27.0-rc3.tar.gz
-WORKDIR /opt/cmake/source
-RUN ./bootstrap && make && make install
+RUN CMAKE_VERSION=3.27.0-rc3 && \
+    CMAKE_URL=https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION} && \
+    CMAKE_SCRIPT=cmake-${CMAKE_VERSION}-linux-x86_64.sh && \
+    wget --quiet ${CMAKE_URL}/${CMAKE_SCRIPT} && \
+    mkdir -p /opt/cmake && \
+    sh ${CMAKE_SCRIPT} --skip-license --prefix=/opt/cmake && \
+    rm cmake*
+ENV PATH=/opt/cmake/bin:$PATH
 
 ###############
 # suitesparse #


### PR DESCRIPTION
Adapted from what I wrote for ArborX https://github.com/arborx/ArborX/blob/c74a6dec6c4acdec22db91573d8cfb99cc6fff6c/docker/Dockerfile.hipcc#L30-L53

We also use that in Kokkos

My take is unless you need it on some exotic system, if you build cmake you are doing it wrong.
I suggest we download binaries instead of building from source.  It will speed things up considerably.