### PR TITLE
Do not remove Trilinos source for ex_01_configure

### DIFF
--- a/dockerfiles/trilinos_demo
+++ b/dockerfiles/trilinos_demo
@@ -57,7 +57,7 @@ RUN wget -nv https://github.com/trilinos/Trilinos/archive/refs/tags/trilinos-rel
     ../do-configure-trilinos.sh && popd && \
     rm do-configure-trilinos.sh && \
     cmake --build build --parallel 4 && cmake --install build --prefix . && \
-    rm -rf build source
+    rm -rf build
 
 # kokkos
 RUN git clone --depth 1 --branch 4.0.01 https://github.com/kokkos/kokkos.git && cmake -S kokkos -B kokkos/build -DKokkos_ENABLE_OPENMP=ON && cmake --build kokkos/build/ --parallel 4 && cmake --install kokkos/build/ --prefix /opt/kokkos && rm -rf kokkos/


### PR DESCRIPTION
For one exercise in the tutorial, where we actually configure and build Trilinos, we need access to the source code. Hence, do not remove it.