### PR TITLE
make cmake install architecture agnostic

### DIFF
--- a/dockerfiles/trilinos_demo
+++ b/dockerfiles/trilinos_demo
@@ -18,8 +18,9 @@ FROM base AS cmake
 
 # Cmake
 RUN CMAKE_VERSION=3.27.0-rc3 && \
+    ARCH="$(uname -m)" && \
     CMAKE_URL=https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION} && \
-    CMAKE_SCRIPT=cmake-${CMAKE_VERSION}-linux-x86_64.sh && \
+    CMAKE_SCRIPT=cmake-${CMAKE_VERSION}-linux-${ARCH}.sh && \
     wget --quiet ${CMAKE_URL}/${CMAKE_SCRIPT} && \
     mkdir -p /opt/cmake && \
     sh ${CMAKE_SCRIPT} --skip-license --prefix=/opt/cmake && \


### PR DESCRIPTION
The problem comes up when building the container on e.g. an apple silicon mac. As the cmake that gets installed was fixed to `x86_64` it would error out when trying to use CMake to configure Trilinos.

With the PR it should set the arch depending on what the hosting Linux reports.
Ran successful on my M1 Mac and x86.